### PR TITLE
unset server.forward-headers-strategy

### DIFF
--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -1,3 +1,6 @@
 spring:
   application:
     name: gateway
+server:
+  # unset forward-headers-strategy from the common conf, otherwise we get 404 on all apis
+  forward-headers-strategy: ~


### PR DESCRIPTION
With the shared conf, server.forward-headers-strategy was set to framework.
For some reason, this breaks the gateway:
$ curl localhost:80/api/gateway/directory/v1/root-directories -H 'X-Forwarded-Prefix: /gridexplore/'
{"timestamp":"2021-11-25T10:36:01.873+0000","path":"/directory/v1/root-directories","status":404,"error":"Not Found","message":null,"requestId":"49d1d097-1"}

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>