### PR TITLE
Add dynamic simulation server to gateway

### DIFF
--- a/src/main/java/org/gridsuite/gateway/GatewayConfig.java
+++ b/src/main/java/org/gridsuite/gateway/GatewayConfig.java
@@ -56,6 +56,7 @@ public class GatewayConfig {
             .route(p -> context.getBean(SensitivityAnalysisServer.class).getRoute(p))
             .route(p -> context.getBean(LoadFlowServer.class).getRoute(p))
             .route(p -> context.getBean(SecurityAnalysisServer.class).getRoute(p))
+            .route(p -> context.getBean(DynamicSimulationServer.class).getRoute(p))
             .build();
     }
 }

--- a/src/main/java/org/gridsuite/gateway/ServiceURIsConfig.java
+++ b/src/main/java/org/gridsuite/gateway/ServiceURIsConfig.java
@@ -92,4 +92,7 @@ public class ServiceURIsConfig {
 
     @Value("${gridsuite.services.security-analysis-server.base-uri:http://security-analysis-server/}")
     String securityAnalysisServerBaseUri;
+
+    @Value("${gridsuite.services.dynamic-simulation-server.base-uri:http://dynamic-simulation-server/}")
+    String dynamicSimulationServerBaseUri;
 }

--- a/src/main/java/org/gridsuite/gateway/endpoints/DynamicSimulationServer.java
+++ b/src/main/java/org/gridsuite/gateway/endpoints/DynamicSimulationServer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.gridsuite.gateway.endpoints;
+
+import org.gridsuite.gateway.ServiceURIsConfig;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Thang PHAM <quyet-thang.pham at rte-france.com>
+ */
+@Component(value = DynamicSimulationServer.ENDPOINT_NAME)
+public class DynamicSimulationServer implements EndPointServer {
+
+    public static final String ENDPOINT_NAME = "dynamic-simulation";
+
+    private final ServiceURIsConfig servicesURIsConfig;
+
+    public DynamicSimulationServer(ServiceURIsConfig servicesURIsConfig) {
+        this.servicesURIsConfig = servicesURIsConfig;
+    }
+
+    @Override
+    public String getEndpointBaseUri() {
+        return servicesURIsConfig.getDynamicSimulationServerBaseUri();
+    }
+
+    @Override
+    public String getEndpointName() {
+        return ENDPOINT_NAME;
+    }
+}

--- a/src/main/java/org/gridsuite/gateway/endpoints/StudyServer.java
+++ b/src/main/java/org/gridsuite/gateway/endpoints/StudyServer.java
@@ -38,6 +38,6 @@ public class StudyServer implements EndPointElementServer {
     @Override
     public Set<String> getUncontrolledRootPaths() {
         return Set.of("search", "svg-component-libraries", "export-network-formats", "loadflow-default-provider",
-                "security-analysis-default-provider", "sensitivity-analysis-default-provider");
+                "security-analysis-default-provider", "sensitivity-analysis-default-provider", "dynamic-simulation-default-provider");
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -54,3 +54,5 @@ gridsuite:
       base-uri: http://localhost:5008
     security-analysis-server:
       base-uri: http://localhost:5023
+    dynamic-simulation-server:
+      base-uri: http://localhost:5032

--- a/src/test/java/org/gridsuite/gateway/ElementAccessControlTest.java
+++ b/src/test/java/org/gridsuite/gateway/ElementAccessControlTest.java
@@ -133,6 +133,7 @@ public class ElementAccessControlTest {
         stubFor(get(urlEqualTo("/v1/loadflow-default-provider")).withHeader("userId", equalTo("user1")).willReturn(aResponse()));
         stubFor(get(urlEqualTo("/v1/security-analysis-default-provider")).withHeader("userId", equalTo("user1")).willReturn(aResponse()));
         stubFor(get(urlEqualTo("/v1/sensitivity-analysis-default-provider")).withHeader("userId", equalTo("user1")).willReturn(aResponse()));
+        stubFor(get(urlEqualTo("/v1/dynamic-simulation-default-provider")).withHeader("userId", equalTo("user1")).willReturn(aResponse()));
         webClient
             .get().uri("study/v1/search")
             .header("Authorization", "Bearer " + tokenUser1)
@@ -160,6 +161,11 @@ public class ElementAccessControlTest {
                 .expectStatus().isOk();
         webClient
                 .get().uri("study/v1/sensitivity-analysis-default-provider")
+                .header("Authorization", "Bearer " + tokenUser1)
+                .exchange()
+                .expectStatus().isOk();
+        webClient
+                .get().uri("study/v1/dynamic-simulation-default-provider")
                 .header("Authorization", "Bearer " + tokenUser1)
                 .exchange()
                 .expectStatus().isOk();


### PR DESCRIPTION
study-app must call directly to dynamic simulation server to retrieve providers
See PR https://github.com/gridsuite/gridstudy-app/pull/1131