### PR TITLE
More explicit endpoint access control API

### DIFF
--- a/src/main/java/org/gridsuite/gateway/endpoints/ContingencyServer.java
+++ b/src/main/java/org/gridsuite/gateway/endpoints/ContingencyServer.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 @Component(value = ContingencyServer.ENDPOINT_NAME)
-public class ContingencyServer implements EndPointElementServer {
+public class ContingencyServer implements EndPointAccessControlledServer {
 
     public static final String ENDPOINT_NAME = "actions";
 

--- a/src/main/java/org/gridsuite/gateway/endpoints/EndPointAccessControlledServer.java
+++ b/src/main/java/org/gridsuite/gateway/endpoints/EndPointAccessControlledServer.java
@@ -22,7 +22,7 @@ import static org.springframework.http.HttpMethod.*;
  *
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
-public interface EndPointElementServer extends EndPointServer {
+public interface EndPointAccessControlledServer extends EndPointServer {
 
     String QUERY_PARAM_IDS = "ids";
 
@@ -66,7 +66,7 @@ public interface EndPointElementServer extends EndPointServer {
                     return Optional.empty();
                 } else {
                     List<String> ids = request.getQueryParams().get(QUERY_PARAM_IDS);
-                    List<UUID> elementUuids = ids.stream().map(EndPointElementServer::getUuid).filter(Objects::nonNull).collect(Collectors.toList());
+                    List<UUID> elementUuids = ids.stream().map(EndPointAccessControlledServer::getUuid).filter(Objects::nonNull).collect(Collectors.toList());
                     return elementUuids.size() == ids.size() ? Optional.of(AccessControlInfos.create(elementUuids)) : Optional.empty();
                 }
             }

--- a/src/main/java/org/gridsuite/gateway/endpoints/EndPointElementServer.java
+++ b/src/main/java/org/gridsuite/gateway/endpoints/EndPointElementServer.java
@@ -18,15 +18,15 @@ import java.util.stream.Collectors;
 import static org.springframework.http.HttpMethod.*;
 
 /**
+ * {@link EndPointServer Server} with access allowed under defined rules
+ *
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 public interface EndPointElementServer extends EndPointServer {
 
     String QUERY_PARAM_IDS = "ids";
 
-    Set<HttpMethod> ALLOWED_HTTP_METHODS = Set.of(GET, HEAD,
-            PUT, POST, DELETE
-    );
+    Set<HttpMethod> ALLOWED_HTTP_METHODS = Set.of(GET, HEAD, PUT, POST, DELETE);
 
     static UUID getUuid(String uuid) {
         try {
@@ -50,11 +50,6 @@ public interface EndPointElementServer extends EndPointServer {
 
     default boolean isNotControlledRootPath(String rootPath) {
         return getUncontrolledRootPaths().contains(rootPath);
-    }
-
-    @Override
-    default boolean hasElementsAccessControl() {
-        return true;
     }
 
     default Optional<AccessControlInfos> getAccessControlInfos(@NonNull ServerHttpRequest request) {

--- a/src/main/java/org/gridsuite/gateway/endpoints/EndPointServer.java
+++ b/src/main/java/org/gridsuite/gateway/endpoints/EndPointServer.java
@@ -14,6 +14,9 @@ import org.springframework.cloud.gateway.route.builder.PredicateSpec;
 import static org.gridsuite.gateway.GatewayConfig.END_POINT_SERVICE_NAME;
 
 /**
+ * Declare a service/server accessible on this gateway under path {@code <host_gateway>/<service_name>/*}
+ * and redirect it to {@code <host_service>/*}.
+ *
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 public interface EndPointServer {
@@ -26,9 +29,5 @@ public interface EndPointServer {
             .filters(f -> f.rewritePath(String.format("/%s/(.*)", getEndpointName()), "/$1"))
             .metadata(END_POINT_SERVICE_NAME, getEndpointName())
             .uri(getEndpointBaseUri());
-    }
-
-    default boolean hasElementsAccessControl() {
-        return false;
     }
 }

--- a/src/main/java/org/gridsuite/gateway/endpoints/ExploreServer.java
+++ b/src/main/java/org/gridsuite/gateway/endpoints/ExploreServer.java
@@ -23,7 +23,7 @@ import java.util.UUID;
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 @Component(value = ExploreServer.ENDPOINT_NAME)
-public class ExploreServer implements EndPointElementServer {
+public class ExploreServer implements EndPointAccessControlledServer {
 
     public static final String ENDPOINT_NAME = "explore";
 
@@ -37,7 +37,7 @@ public class ExploreServer implements EndPointElementServer {
 
     @Override
     public UUID getElementUuidIfExist(@NonNull RequestPath path) {
-        return (path.elements().size() > 7) ? EndPointElementServer.getUuid(path.elements().get(7).value()) : null;
+        return (path.elements().size() > 7) ? EndPointAccessControlledServer.getUuid(path.elements().get(7).value()) : null;
     }
 
     @Override
@@ -64,12 +64,12 @@ public class ExploreServer implements EndPointElementServer {
                 if (ids == null || ids.size() != 1) {
                     return Optional.empty();
                 } else {
-                    UUID uuid = EndPointElementServer.getUuid(ids.get(0));
+                    UUID uuid = EndPointAccessControlledServer.getUuid(ids.get(0));
                     return uuid == null ? Optional.empty() : Optional.of(AccessControlInfos.create(List.of(uuid)));
                 }
             }
         } else {
-            return EndPointElementServer.super.getAccessControlInfos(request);
+            return EndPointAccessControlledServer.super.getAccessControlInfos(request);
         }
     }
 }

--- a/src/main/java/org/gridsuite/gateway/endpoints/ExploreServer.java
+++ b/src/main/java/org/gridsuite/gateway/endpoints/ExploreServer.java
@@ -51,11 +51,6 @@ public class ExploreServer implements EndPointElementServer {
     }
 
     @Override
-    public boolean hasElementsAccessControl() {
-        return true;
-    }
-
-    @Override
     public Optional<AccessControlInfos> getAccessControlInfos(@NonNull ServerHttpRequest request) {
         RequestPath path = Objects.requireNonNull(request.getPath());
         UUID elementUuid = getElementUuidIfExist(path);

--- a/src/main/java/org/gridsuite/gateway/endpoints/FilterServer.java
+++ b/src/main/java/org/gridsuite/gateway/endpoints/FilterServer.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 @Component(value = FilterServer.ENDPOINT_NAME)
-public class FilterServer implements EndPointElementServer {
+public class FilterServer implements EndPointAccessControlledServer {
 
     public static final String ENDPOINT_NAME = "filter";
 

--- a/src/main/java/org/gridsuite/gateway/endpoints/StudyServer.java
+++ b/src/main/java/org/gridsuite/gateway/endpoints/StudyServer.java
@@ -15,7 +15,7 @@ import java.util.Set;
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 @Component(value = StudyServer.ENDPOINT_NAME)
-public class StudyServer implements EndPointElementServer {
+public class StudyServer implements EndPointAccessControlledServer {
 
     public static final String ENDPOINT_NAME = "study";
 

--- a/src/main/java/org/gridsuite/gateway/filters/ElementAccessControllerGlobalPreFilter.java
+++ b/src/main/java/org/gridsuite/gateway/filters/ElementAccessControllerGlobalPreFilter.java
@@ -48,11 +48,10 @@ public class ElementAccessControllerGlobalPreFilter extends AbstractGlobalPreFil
     private static final Logger LOGGER = LoggerFactory.getLogger(ElementAccessControllerGlobalPreFilter.class);
 
     private static final String ROOT_CATEGORY_REACTOR = "reactor.";
-
     private static final String ELEMENTS_ROOT_PATH = "elements";
+    private static final Pattern PATH_API_VERSION = Pattern.compile("^/v(\\d)+/.*");
 
     private final WebClient webClient;
-
     private final ApplicationContext applicationContext;
 
     public ElementAccessControllerGlobalPreFilter(ApplicationContext context, ServiceURIsConfig servicesURIsConfig, WebClient.Builder webClientBuilder) {
@@ -73,7 +72,7 @@ public class ElementAccessControllerGlobalPreFilter extends AbstractGlobalPreFil
         RequestPath path = exchange.getRequest().getPath();
 
         // Filter only requests to the endpoint servers with this pattern: /v<number>/<appli_root_path>
-        if (!Pattern.matches("/v(\\d)+/.*", path.value())) {
+        if (!PATH_API_VERSION.matcher(path.value()).matches()) {
             return chain.filter(exchange);
         }
 


### PR DESCRIPTION
If we look that the `hasElementsAccessControl()` is always `false` with implementations of `EndPointServer`, and always `true` with the override of `EndPointElementServer`.  
When analysing `ElementAccessControllerGlobalPreFilter`, it is in fact considering that if there is elements access control, then it is an `EndPointElementServer` (cast object).

This PR:
- [x] remove `hasElementsAccessControl()` from `EndPointServer`
- [x] rename `EndPointElementServer` to `EndPointAccessControlledServer` to be more explicit of what the interface permit
- [x] optimize regex by compiling pattern once and reusing it
