### PR TITLE
Use spring-boot-starter-actuator for compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,16 +111,11 @@
             <artifactId>spring-cloud-starter-gateway</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
         <!-- runtime dependencies -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-            <scope>runtime</scope>
-        </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>


### PR DESCRIPTION
For consistency with loadflow-server, network-conversion-server, etc. we set spring-boot-starter-actuator with compile scope.