### PR TITLE
Use token profile and delete check users

### DIFF
--- a/src/main/java/org/gridsuite/gateway/GatewayConfig.java
+++ b/src/main/java/org/gridsuite/gateway/GatewayConfig.java
@@ -26,7 +26,6 @@ public class GatewayConfig {
     public static final String END_POINT_SERVICE_NAME = "end_point_service_name";
 
     public static final String HEADER_USER_ID = "userId";
-    public static final String HEADER_CLIENT_ID = "clientId";
     public static final String HEADER_ROLES = "roles";
 
     @Bean

--- a/src/main/java/org/gridsuite/gateway/GatewayConfig.java
+++ b/src/main/java/org/gridsuite/gateway/GatewayConfig.java
@@ -27,6 +27,7 @@ public class GatewayConfig {
 
     public static final String HEADER_USER_ID = "userId";
     public static final String HEADER_CLIENT_ID = "clientId";
+    public static final String HEADER_ROLES = "roles";
 
     @Bean
     public RouteLocator myRoutes(RouteLocatorBuilder builder, ApplicationContext context) {

--- a/src/main/java/org/gridsuite/gateway/filters/AbstractGlobalPreFilter.java
+++ b/src/main/java/org/gridsuite/gateway/filters/AbstractGlobalPreFilter.java
@@ -24,7 +24,6 @@ import static org.gridsuite.gateway.GatewayConfig.HEADER_USER_ID;
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 public abstract class AbstractGlobalPreFilter implements GlobalFilter, Ordered {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractGlobalPreFilter.class);
 
     protected final UserAdminService userAdminService;
 

--- a/src/main/java/org/gridsuite/gateway/filters/AbstractGlobalPreFilter.java
+++ b/src/main/java/org/gridsuite/gateway/filters/AbstractGlobalPreFilter.java
@@ -7,8 +7,6 @@
 package org.gridsuite.gateway.filters;
 
 import org.gridsuite.gateway.services.UserAdminService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/org/gridsuite/gateway/filters/AbstractGlobalPreFilter.java
+++ b/src/main/java/org/gridsuite/gateway/filters/AbstractGlobalPreFilter.java
@@ -6,6 +6,9 @@
  */
 package org.gridsuite.gateway.filters;
 
+import org.gridsuite.gateway.services.UserAdminService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpHeaders;
@@ -13,17 +16,50 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+
+import static org.gridsuite.gateway.GatewayConfig.HEADER_USER_ID;
+
 /**
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 public abstract class AbstractGlobalPreFilter implements GlobalFilter, Ordered {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractGlobalPreFilter.class);
 
+    protected final UserAdminService userAdminService;
+
+    protected AbstractGlobalPreFilter(UserAdminService userAdminService) {
+        this.userAdminService = userAdminService;
+    }
+
+    /**
+     * Completes the exchange with the specified HTTP status code.
+     *
+     * IMPORTANT NOTE: This method is currently called only when authentication or authorization fails
+     * in the filter chain. Therefore, we record a failed connection attempt (isConnectionAccepted=false)
+     * here to track unsuccessful login attempts. If the usage of this method changes in the future
+     * (e.g., if it's called for non-auth failures), this implementation should be reviewed.
+     */
     protected Mono<Void> completeWithCode(ServerWebExchange exchange, HttpStatus code) {
         exchange.getResponse().setStatusCode(code);
         if ("websocket".equalsIgnoreCase(exchange.getRequest().getHeaders().getUpgrade())) {
             // Force the connection to close for websockets handshakes to workaround apache
             // httpd reusing the connection for all subsequent requests in this connection.
             exchange.getResponse().getHeaders().set(HttpHeaders.CONNECTION, "close");
+        }
+
+        // Record failed connection attempt if user ID is present
+        HttpHeaders httpHeaders = exchange.getRequest().getHeaders();
+        List<String> maybeSubList = httpHeaders.get(HEADER_USER_ID);
+
+        if (maybeSubList != null && !maybeSubList.isEmpty()) {
+            String sub = maybeSubList.getFirst();
+            return userAdminService.userRecordConnection(sub, false)
+                    .onErrorResume(error -> {
+                        LOGGER.warn("Failed to record failed connection for user {}: {}", sub, error.getMessage());
+                        return Mono.empty();
+                    })
+                    .then(exchange.getResponse().setComplete());
         }
         return exchange.getResponse().setComplete();
     }

--- a/src/main/java/org/gridsuite/gateway/filters/AbstractGlobalPreFilter.java
+++ b/src/main/java/org/gridsuite/gateway/filters/AbstractGlobalPreFilter.java
@@ -54,12 +54,7 @@ public abstract class AbstractGlobalPreFilter implements GlobalFilter, Ordered {
 
         if (maybeSubList != null && !maybeSubList.isEmpty()) {
             String sub = maybeSubList.getFirst();
-            return userAdminService.userRecordConnection(sub, false)
-                    .onErrorResume(error -> {
-                        LOGGER.warn("Failed to record failed connection for user {}: {}", sub, error.getMessage());
-                        return Mono.empty();
-                    })
-                    .then(exchange.getResponse().setComplete());
+            userAdminService.userRecordConnection(sub, false).subscribe();
         }
         return exchange.getResponse().setComplete();
     }

--- a/src/main/java/org/gridsuite/gateway/filters/AbstractGlobalPreFilter.java
+++ b/src/main/java/org/gridsuite/gateway/filters/AbstractGlobalPreFilter.java
@@ -7,6 +7,8 @@
 package org.gridsuite.gateway.filters;
 
 import org.gridsuite.gateway.services.UserAdminService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpHeaders;
@@ -22,6 +24,8 @@ import static org.gridsuite.gateway.GatewayConfig.HEADER_USER_ID;
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 public abstract class AbstractGlobalPreFilter implements GlobalFilter, Ordered {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractGlobalPreFilter.class);
 
     protected final UserAdminService userAdminService;
 
@@ -45,7 +49,8 @@ public abstract class AbstractGlobalPreFilter implements GlobalFilter, Ordered {
     protected Mono<Void> completeWithError(ServerWebExchange exchange, HttpStatus status) {
         // Ensure we're only using this method with error status codes
         if (!status.isError()) {
-            throw new IllegalArgumentException("completeWithError should only be used with error status codes, received: " + status);
+            LOGGER.warn("completeWithError was called with a non-error status code: {}. " +
+                    "This method is intended for error responses only.", status);
         }
 
         exchange.getResponse().setStatusCode(status);

--- a/src/main/java/org/gridsuite/gateway/filters/SupervisionAccessControlFilter.java
+++ b/src/main/java/org/gridsuite/gateway/filters/SupervisionAccessControlFilter.java
@@ -6,6 +6,7 @@
  */
 package org.gridsuite.gateway.filters;
 
+import org.gridsuite.gateway.services.UserAdminService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
@@ -44,6 +45,10 @@ public class SupervisionAccessControlFilter extends AbstractGlobalPreFilter {
     private static final Logger LOGGER = LoggerFactory.getLogger(SupervisionAccessControlFilter.class);
     private static final Pattern SUPERVISION_PATTERN = Pattern.compile("^/v\\d+/supervision(/.*)?$");
     public static final String ACCESS_TO_SUPERVISION_ENDPOINT_IS_NOT_ALLOWED = "{}: 403 Forbidden, Access to supervision endpoint is not allowed";
+
+    public SupervisionAccessControlFilter(UserAdminService userAdminService) {
+        super(userAdminService);
+    }
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {

--- a/src/main/java/org/gridsuite/gateway/filters/SupervisionAccessControlFilter.java
+++ b/src/main/java/org/gridsuite/gateway/filters/SupervisionAccessControlFilter.java
@@ -56,7 +56,7 @@ public class SupervisionAccessControlFilter extends AbstractGlobalPreFilter {
         if (SUPERVISION_PATTERN.matcher(path).matches()) {
             LOGGER.info(ACCESS_TO_SUPERVISION_ENDPOINT_IS_NOT_ALLOWED,
                     exchange.getRequest().getPath());
-            return completeWithCode(exchange, HttpStatus.FORBIDDEN);
+            return completeWithError(exchange, HttpStatus.FORBIDDEN);
         }
 
         return chain.filter(exchange);

--- a/src/main/java/org/gridsuite/gateway/filters/UserAdminControlGlobalPreFilter.java
+++ b/src/main/java/org/gridsuite/gateway/filters/UserAdminControlGlobalPreFilter.java
@@ -53,7 +53,7 @@ public class UserAdminControlGlobalPreFilter extends AbstractGlobalPreFilter {
             return chain.filter(exchange);
         }
 
-        return completeWithCode(exchange, HttpStatus.UNAUTHORIZED);
+        return completeWithError(exchange, HttpStatus.UNAUTHORIZED);
     }
 
     @Override

--- a/src/main/java/org/gridsuite/gateway/services/UserAdminService.java
+++ b/src/main/java/org/gridsuite/gateway/services/UserAdminService.java
@@ -23,22 +23,23 @@ public class UserAdminService {
 
     private static final String USER_ADMIN_SERVER_ROOT_PATH = DELIMITER + USER_ADMIN_SERVER_API_VERSION + DELIMITER + "users";
 
+    private static final String USER_ADMIN_RECORD_USER_CONNECTION_URL = USER_ADMIN_SERVER_ROOT_PATH + DELIMITER + "{sub}/record-connection";
+
     private final WebClient webClient;
 
     public UserAdminService(ServiceURIsConfig servicesURIsConfig, WebClient.Builder webClientBuilder) {
         this.webClient = webClientBuilder.baseUrl(servicesURIsConfig.getUserAdminServerBaseUri()).build();
     }
 
-    public Mono<Boolean> userExists(String sub) {
+    public Mono<Void> userRecordConnection(String sub, boolean isConnectionAccepted) {
         return webClient
-            .head()
-            .uri(uriBuilder -> uriBuilder
-                    .path(USER_ADMIN_SERVER_ROOT_PATH + DELIMITER + sub)
-                    .build()
-            )
-            .retrieve()
-            .toBodilessEntity()
-            .single()
-            .map(entity -> entity.getStatusCode().value() == 200);
+                .head()
+                .uri(uriBuilder -> uriBuilder
+                        .path(USER_ADMIN_RECORD_USER_CONNECTION_URL)
+                        .queryParam("isConnectionAccepted", isConnectionAccepted)
+                        .build(sub)  // Replace {sub} in the path with the actual value
+                )
+                .retrieve()
+                .bodyToMono(Void.class);
     }
 }

--- a/src/main/resources/allowed-issuers.yml
+++ b/src/main/resources/allowed-issuers.yml
@@ -1,3 +1,3 @@
-allowed-issuers: #, #
+allowed-issuers: http://172.17.0.1:9090
 client_id: #
 client_secret: #

--- a/src/main/resources/allowed-issuers.yml
+++ b/src/main/resources/allowed-issuers.yml
@@ -1,3 +1,5 @@
 allowed-issuers: http://172.17.0.1:9090
+allowed-audiences: gridexplore-client, gridadmin-client, griddyna-client, gridstudy-client, gridexplore-local, gridadmin-local, griddyna-local, gridstudy-local
+allowed-clients:
 client_id: #
 client_secret: #

--- a/src/main/resources/allowed-issuers.yml
+++ b/src/main/resources/allowed-issuers.yml
@@ -1,5 +1,5 @@
-allowed-issuers: http://172.17.0.1:9090
-allowed-audiences: gridexplore-client, gridadmin-client, griddyna-client, gridstudy-client, gridexplore-local, gridadmin-local, griddyna-local, gridstudy-local
-allowed-clients:
+allowed-issuers: #, #
+allowed-audiences: #, #
+allowed-clients: #, #
 client_id: #
 client_secret: #

--- a/src/main/resources/allowed-issuers.yml
+++ b/src/main/resources/allowed-issuers.yml
@@ -1,5 +1,5 @@
 allowed-issuers: #, #
-allowed-audiences: #, #
-allowed-clients: #, #
+allowed-audiences:
+allowed-clients:
 client_id: #
 client_secret: #

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -72,4 +72,6 @@ gridsuite:
       base-uri: http://localhost:5035
     user-identity-server:
       base-uri: http://localhost:5034
-    
+
+allowed-issuers: http://172.17.0.1:9090
+allowed-audiences: gridexplore-client, gridadmin-client, griddyna-client, gridstudy-client, gridexplore-local, gridadmin-local, griddyna-local, gridstudy-local

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -73,5 +73,6 @@ gridsuite:
     user-identity-server:
       base-uri: http://localhost:5034
 
+# Note: The issuer configured in Docker Compose must match the one used here. Using localhost instead will not work.
 allowed-issuers: http://172.17.0.1:9090
 allowed-audiences: gridexplore-client, gridadmin-client, griddyna-client, gridstudy-client, gridexplore-local, gridadmin-local, griddyna-local, gridstudy-local

--- a/src/test/java/org/gridsuite/gateway/ElementAccessControlTest.java
+++ b/src/test/java/org/gridsuite/gateway/ElementAccessControlTest.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
         "gridsuite.services.user-admin-server.base-uri=http://localhost:${wiremock.server.port}",
         "gridsuite.services.sensitivity-analysis-server.base-uri=http://localhost:${wiremock.server.port}",
         "gridsuite.services.study-config-server.base-uri=http://localhost:${wiremock.server.port}",
+        "allowed-issuers=http://localhost:${wiremock.server.port}",
         "allowed-audiences=test.app,chmits",
         "allowed-clients=chmits",
     }

--- a/src/test/java/org/gridsuite/gateway/ElementAccessControlTest.java
+++ b/src/test/java/org/gridsuite/gateway/ElementAccessControlTest.java
@@ -48,6 +48,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
         "gridsuite.services.user-admin-server.base-uri=http://localhost:${wiremock.server.port}",
         "gridsuite.services.sensitivity-analysis-server.base-uri=http://localhost:${wiremock.server.port}",
         "gridsuite.services.study-config-server.base-uri=http://localhost:${wiremock.server.port}",
+        "allowed-audiences=test.app,chmits",
+        "allowed-clients=chmits",
     }
 )
 @AutoConfigureWireMock(port = 0)

--- a/src/test/java/org/gridsuite/gateway/TokenValidationTest.java
+++ b/src/test/java/org/gridsuite/gateway/TokenValidationTest.java
@@ -73,6 +73,7 @@ import static org.junit.jupiter.api.Assertions.fail;
         "gridsuite.services.user-identity-server.base-uri=http://localhost:${wiremock.server.port}",
         "allowed-issuers=http://localhost:${wiremock.server.port}",
         "allowed-audiences=test.app,chmits",
+        "allowed-clients=chmits",
     })
 @AutoConfigureWireMock(port = 0)
 class TokenValidationTest {

--- a/src/test/java/org/gridsuite/gateway/TokenValidationTest.java
+++ b/src/test/java/org/gridsuite/gateway/TokenValidationTest.java
@@ -42,7 +42,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
 


### PR DESCRIPTION
- This PR enhances API security by implementing token audience validation against a configurable whitelist for both JWT and opaque tokens, ensuring only authorized applications can access the gateway. 
Split audience validation into two separate lists:
        * allowedAudiences: Exclusively for validating the aud claim in JWT tokens
        * allowedClients: For validating client_id claim in JWT tokens and client IDs in opaque tokens
- Profile claims from JWT tokens are now extracted and added as roles headers to downstream requests, enabling role-based authorization across backend services. 
- User admin validation checks were removed.