### PR TITLE
Allow to have a prefix path in the backends base-uris (previously only just scheme:host:port).

### DIFF
--- a/src/main/java/org/gridsuite/gateway/endpoints/EndPointServer.java
+++ b/src/main/java/org/gridsuite/gateway/endpoints/EndPointServer.java
@@ -11,6 +11,8 @@ import org.springframework.cloud.gateway.route.Route;
 import org.springframework.cloud.gateway.route.builder.Buildable;
 import org.springframework.cloud.gateway.route.builder.PredicateSpec;
 
+import java.net.URI;
+
 import static org.gridsuite.gateway.GatewayConfig.END_POINT_SERVICE_NAME;
 
 /**
@@ -23,7 +25,10 @@ public interface EndPointServer {
 
     default Buildable<Route> getRoute(@NonNull PredicateSpec p) {
         return p.path(String.format("/%s/**", getEndpointName()))
-            .filters(f -> f.rewritePath(String.format("/%s/(.*)", getEndpointName()), "/$1"))
+            .filters(f -> f
+                    .rewritePath(String.format("/%s/(.*)", getEndpointName()), "/$1")
+                    .prefixPath(URI.create(getEndpointBaseUri()).getPath())
+            )
             .metadata(END_POINT_SERVICE_NAME, getEndpointName())
             .uri(getEndpointBaseUri());
     }

--- a/src/test/java/org/gridsuite/gateway/BaseUriTest.java
+++ b/src/test/java/org/gridsuite/gateway/BaseUriTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.gateway;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.gridsuite.gateway.filters.TokenValidatorGlobalPreFilter;
+import org.gridsuite.gateway.filters.UserAdminControlGlobalPreFilter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.server.ServerWebExchange;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        // case-server chosen without reason for this test, just to use a prefix
+        properties = {"powsybl.services.case-server.base-uri=http://localhost:${wiremock.server.port}/prefix"})
+@AutoConfigureWireMock(port = 0)
+class BaseUriTest {
+
+    // Mock the filters that require setup and just get in the way of this test
+    @MockitoBean
+    TokenValidatorGlobalPreFilter unusedTokenValidatorGlobalPreFilter;
+    @MockitoBean
+    UserAdminControlGlobalPreFilter unusedUserAdminControlGlobalPreFilter;
+
+    @Autowired
+    private WebTestClient webClient;
+
+    @Test
+    void testBaseUriPrefix() {
+
+        mockFilterAsNoOp(unusedTokenValidatorGlobalPreFilter);
+        mockFilterAsNoOp(unusedUserAdminControlGlobalPreFilter);
+
+        stubFor(get(urlEqualTo("/prefix/test")).willReturn(aResponse().withBody("prefixtest")));
+
+        webClient.get()
+                .uri("/case/test")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class).isEqualTo("prefixtest");
+    }
+
+    private void mockFilterAsNoOp(GlobalFilter globalFilter) {
+        when(globalFilter.filter(any(), any())).thenAnswer(
+            inv -> {
+                GatewayFilterChain chain = inv.getArgument(1);
+                ServerWebExchange exchange = inv.getArgument(0);
+                return chain.filter(exchange);
+            });
+    }
+}


### PR DESCRIPTION
This makes it like in our other servers base-uris using resttemplates for example. This is useful when hosting the microservice not at /

See https://github.com/spring-cloud/spring-cloud-gateway/issues/881 :

Question:
> With
>   URI backendUri = URI.create("http://server.name/some/backend/root");
> and .route(r -> r.uri(backendUri))
> I expect a request to http://server.name/some/backend/root/**, but currently I get a request to http://server.name/**
> but I can workaround this using the prefixPath filter:
>   .route(r ->r r.filters(f -> f.prefixPath(backendUri.getPath())).uri(backendUri))

Answer:
> Yes this is intentional, we only take the host and port from the URI, the path must be set via the set path filter, it will not append it.

## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->


