### PR TITLE
Upstream deprecations/renames (no changes)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-gateway</artifactId>
+            <artifactId>spring-cloud-starter-gateway-server-webflux</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -6,7 +6,6 @@ server:
   forward-headers-strategy: ~
   netty:
     max-initial-line-length: 64000
-    max-chunk-size: 64000
 powsybl-ws:
   autoconfigure:
     base-exception-handler:


### PR DESCRIPTION
> [main] WARN  org.springframework.cloud.gateway.server.webflux.starter.StarterDeprecatedAutoConfiguration -
> **********************************************************
> spring-cloud-starter-gateway is deprecated. It will be removed in the next major release. Please use spring-cloud-starter-gateway-server-webflux instead.

obvious

> [main] ERROR org.springframework.boot.context.properties.migrator.PropertiesMigrationListener -
> The use of configuration keys that are no longer supported was found in the environment:
> Property source 'Config resource 'class path resource [config/application.yaml]' via location 'optional:classpath:/config/'':
> 	Key: server.netty.max-chunk-size
> 		Line: 9
> 		Reason: Deprecated for removal in Reactor Netty.
> Please refer to the release notes or reference guide for potential alternatives.

No need for alternative, we had raised the limit from 8kb to 64kb, but newer versions eliminated this limit entirely so it behaves like +inf which is fine for us

## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->



