### PR TITLE
Add third token option: split between a cookie and query param

### DIFF
--- a/src/main/java/org/gridsuite/gateway/filters/TokenValidatorGlobalPreFilter.java
+++ b/src/main/java/org/gridsuite/gateway/filters/TokenValidatorGlobalPreFilter.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.core.Ordered;
+import org.springframework.http.HttpCookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -34,8 +35,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -57,6 +60,37 @@ public class TokenValidatorGlobalPreFilter extends AbstractGlobalPreFilter {
     private static final Logger LOGGER = LoggerFactory.getLogger(TokenValidatorGlobalPreFilter.class);
     public static final String UNAUTHORIZED_THE_TOKEN_CANNOT_BE_TRUSTED = "{}: 401 Unauthorized, The token cannot be trusted";
     public static final String CACHE_OUTDATED = "{}: Bad JSON Object Signing and Encryption, cache outdated";
+
+    /**
+     * Name of the query string parameter carrying a whole (unsplit) access token by itself - the
+     * original, simpler mechanism, kept as a fallback for requests that can't carry a custom
+     * Authorization header (e.g. WebSocket connections) but don't need XOR-splitting (see
+     * {@link #ACCESS_TOKEN_SHARE_COOKIE_NAME}).
+     */
+    public static final String ACCESS_TOKEN_QUERY_PARAM = "access_token";
+
+    /**
+     * For requests that can't carry a custom Authorization header (WebSocket connections), the
+     * frontend can instead split the access token in two shares via XOR: a cryptographically
+     * random share carried by this cookie, and the complementary share carried by the
+     * {@link #ACCESS_TOKEN_SHARE_QUERY_PARAM} query parameter. Neither channel alone reveals the
+     * token, and neither is ever usable by itself - the gateway only recombines them into a
+     * token when both are present together (see {@link #filter}) - so a lone copy of this
+     * cookie, automatically replayed by the browser on any request (including a cross-site one
+     * an attacker's page could trigger), can't be used to authenticate on its own.
+     *
+     * <p>Note: We could in the future also support a plain (unsplit) {@code AccessToken} cookie
+     * carrying a whole token by itself, for cases where CSRF isn't a concern - but that's not
+     * needed today.
+     */
+    public static final String ACCESS_TOKEN_SHARE_COOKIE_NAME = "AccessTokenShare";
+
+    /**
+     * Name of the query string parameter carrying the token's XOR-complement share (see
+     * {@link #ACCESS_TOKEN_SHARE_COOKIE_NAME}).
+     */
+    public static final String ACCESS_TOKEN_SHARE_QUERY_PARAM = "access_token_share";
+
     private final GatewayService gatewayService;
     private final UserIdentityService userIdentityService;
 
@@ -91,16 +125,22 @@ public class TokenValidatorGlobalPreFilter extends AbstractGlobalPreFilter {
         LOGGER.debug("Filter : {}", getClass().getSimpleName());
         ServerHttpRequest req = exchange.getRequest();
         List<String> ls = req.getHeaders().get(HttpHeaders.AUTHORIZATION);
-        List<String> queryls = req.getQueryParams().get("access_token");
+        List<String> queryls = req.getQueryParams().get(ACCESS_TOKEN_QUERY_PARAM);
+        List<HttpCookie> accessTokenShareCookieLs = req.getCookies().get(ACCESS_TOKEN_SHARE_COOKIE_NAME);
+        List<String> queryShareLs = req.getQueryParams().get(ACCESS_TOKEN_SHARE_QUERY_PARAM);
 
-        if (ls == null && queryls == null) {
-            LOGGER.info("{}: 401 Unauthorized, Authorization header or access_token query parameter is required",
-                exchange.getRequest().getPath());
-            return completeWithError(exchange, HttpStatus.UNAUTHORIZED);
-        }
-
+        // Priority: Authorization header first; then the access_token query parameter (a whole
+        // token by itself); then the AccessTokenShare cookie / access_token_share query
+        // parameter pair, XOR-recombined below - these last two exist for requests that can't
+        // carry a custom Authorization header (WebSocket connections). A lone share (cookie or
+        // query parameter alone, without its counterpart) is never usable by itself, even if it
+        // happens to be a whole valid token: the split scheme exists specifically to defeat CSRF
+        // (a lone cookie is automatically replayed by the browser on any request, including a
+        // cross-site one an attacker's page could trigger), so treating either share as usable
+        // alone would defeat that purpose.
+        //
         // For now we only handle one token. If needed, we can adapt this code to check
-        // multiple tokens and accept the connection if at least one of them is valid
+        // multiple tokens and accept the connection if at least one of them is valid.
         String token;
         if (ls != null) {
             String authorization = ls.get(0);
@@ -113,8 +153,19 @@ public class TokenValidatorGlobalPreFilter extends AbstractGlobalPreFilter {
             }
 
             token = arr.get(1);
-        } else {
+        } else if (queryls != null) {
             token = queryls.get(0);
+        } else if (accessTokenShareCookieLs != null && queryShareLs != null) {
+            token = recoverSplitToken(accessTokenShareCookieLs.get(0).getValue(), queryShareLs.get(0));
+            if (token == null) {
+                LOGGER.info("{}: 400 Bad Request, {} cookie and {} query parameter could not be recombined into a valid token",
+                    exchange.getRequest().getPath(), ACCESS_TOKEN_SHARE_COOKIE_NAME, ACCESS_TOKEN_SHARE_QUERY_PARAM);
+                return completeWithError(exchange, HttpStatus.BAD_REQUEST);
+            }
+        } else {
+            LOGGER.info("{}: 401 Unauthorized, Authorization header, {} query parameter, or {} cookie + {} query parameter pair is required",
+                exchange.getRequest().getPath(), ACCESS_TOKEN_QUERY_PARAM, ACCESS_TOKEN_SHARE_COOKIE_NAME, ACCESS_TOKEN_SHARE_QUERY_PARAM);
+            return completeWithError(exchange, HttpStatus.UNAUTHORIZED);
         }
 
         JWT jwt;
@@ -156,6 +207,41 @@ public class TokenValidatorGlobalPreFilter extends AbstractGlobalPreFilter {
         }
     }
 
+    /**
+     * Recombines the token's two XOR shares: the random share from the {@code AccessTokenShare}
+     * cookie, and the complementary share from the {@code access_token_share} query parameter
+     * (see {@link #filter}). Both shares are base64url-encoded (no padding required).
+     *
+     * @return the recovered token, or {@code null} if either share is malformed (invalid
+     * base64url) or the two shares' decoded lengths don't match.
+     */
+    private static String recoverSplitToken(String cookieShare, String queryShare) {
+        byte[] random;
+        byte[] xored;
+        try {
+            random = Base64.getUrlDecoder().decode(cookieShare);
+            xored = Base64.getUrlDecoder().decode(queryShare);
+        } catch (IllegalArgumentException e) {
+            // Swallow the exception (its message is not logged) and fall through to the same
+            // generic null every other rejection below returns: for security-sensitive code
+            // like this, surfacing exactly why recombination failed (e.g. malformed base64url)
+            // would give an attacker probing this endpoint an oracle to iteratively refine
+            // their input, for no legitimate benefit.
+            return null;
+        }
+        if (random.length == 0 || random.length != xored.length) {
+            // Same rationale as the catch block above: reject with the same generic null
+            // instead of distinguishing "empty" from "mismatched length" - don't give an
+            // attacker any more information than "this pair doesn't recombine into a token".
+            return null;
+        }
+        byte[] token = new byte[random.length];
+        for (int i = 0; i < token.length; i++) {
+            token[i] = (byte) (random[i] ^ xored[i]);
+        }
+        return new String(token, StandardCharsets.UTF_8);
+    }
+
     private Mono<Void> validateOpaqueReferenceToken(String issBaseUri, String token, ServerWebExchange exchange,
             @SuppressWarnings("checkstyle:LambdaBodyLength")
             GatewayFilterChain chain) {
@@ -175,6 +261,11 @@ public class TokenValidatorGlobalPreFilter extends AbstractGlobalPreFilter {
 
                         // TODO really add the client_id header instead of userid
                         // Build mutated request with userId header
+                        // Maybe in the future we could strip the already-checked auth carriers
+                        // (Authorization header, AccessTokenShare cookie, access_token /
+                        // access_token_share query parameters) here before forwarding
+                        // downstream, since no microservice needs them once the gateway has
+                        // authenticated the request.
                         ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
                                 .header(HEADER_USER_ID, tokenIntrospection.getClientId())
                                 .build();
@@ -289,6 +380,10 @@ public class TokenValidatorGlobalPreFilter extends AbstractGlobalPreFilter {
 
         ServerWebExchange exchange = filterInfos.getExchange();
         //we add the subject header
+        // Maybe in the future we could strip the already-checked auth carriers (Authorization
+        // header, AccessTokenShare cookie, access_token / access_token_share query parameters)
+        // here before forwarding downstream, since no microservice needs them once the gateway
+        // has authenticated the request.
         ServerHttpRequest.Builder requestBuilder = exchange.getRequest().mutate()
                 .header(HEADER_USER_ID, filterInfos.getJwtClaimsSet().getSubject());
 

--- a/src/test/java/org/gridsuite/gateway/TokenValidationTest.java
+++ b/src/test/java/org/gridsuite/gateway/TokenValidationTest.java
@@ -40,12 +40,15 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.gridsuite.gateway.filters.TokenValidatorGlobalPreFilter.ACCESS_TOKEN_SHARE_COOKIE_NAME;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -196,13 +199,43 @@ class TokenValidationTest {
         tokenWithInvalidClientId = signedJWTInvalidClientId.serialize();
     }
 
-    private void testWebsocket(String name) throws Exception {
-        //Test a websocket with token in query parameters
+    /**
+     * Splits {@code token} into its two base64 XOR shares, mirroring what the frontend can do.
+     *
+     * <p>Note: for simplicity because of how these tests are architected (the token contains
+     * wiremock's dynamic port), we rewrite this small client code and compute this dynamically
+     * instead of hardcoding an example token + its shares as string constants.
+     */
+    private static String[] splitToken(String token) {
+        byte[] tokenBytes = token.getBytes(StandardCharsets.UTF_8);
+        byte[] random = new byte[tokenBytes.length];
+        new SecureRandom().nextBytes(random);
+        byte[] xored = new byte[tokenBytes.length];
+        for (int i = 0; i < tokenBytes.length; i++) {
+            xored[i] = (byte) (tokenBytes[i] ^ random[i]);
+        }
+        Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        return new String[] {encoder.encodeToString(random), encoder.encodeToString(xored)};
+    }
+
+    /**
+     * Drives a websocket handshake through the gateway, authenticated either with the whole
+     * (unsplit) {@code token} in the access_token query parameter ({@code splitAuth} false), or
+     * with {@code token} XOR-split across the AccessTokenShare cookie and the
+     * access_token_share query parameter ({@code splitAuth} true).
+     */
+    private void testWebsocket(String name, boolean splitAuth, String token) throws Exception {
         WebSocketClient client = new StandardWebSocketClient();
         HttpHeaders headers = new HttpHeaders();
-        Mono<Void> wsconnection = client.execute(
-            URI.create("ws://localhost:" + this.localServerPort + "/" + name + "/notify?access_token=" + token), headers,
-            ws -> ws.receive().then());
+        URI uri;
+        if (splitAuth) {
+            String[] shares = splitToken(token);
+            headers.add(HttpHeaders.COOKIE, ACCESS_TOKEN_SHARE_COOKIE_NAME + "=" + shares[0]);
+            uri = URI.create("ws://localhost:" + this.localServerPort + "/" + name + "/notify?access_token_share=" + shares[1]);
+        } else {
+            uri = URI.create("ws://localhost:" + this.localServerPort + "/" + name + "/notify?access_token=" + token);
+        }
+        Mono<Void> wsconnection = client.execute(uri, headers, ws -> ws.receive().then());
         wsconnection.subscribe();
 
         // Busy loop waiting to check that spring-gateway contacted our wiremock server
@@ -234,79 +267,127 @@ class TokenValidationTest {
     }
 
     @Test
+    // Note: Not sure if it's very useful to test all these routes and various json returns here..
     void gatewayTest() {
         initStubForJwk();
 
         UUID elementUuid = UUID.randomUUID();
 
-        stubFor(head(urlEqualTo(String.format("/v1/elements?ids=%s", elementUuid))).withPort(port).withHeader("userId", equalTo("chmits"))
+        // Seems unused: no testToken call below ever hits this route.
+        stubFor(head(urlPathEqualTo("/v1/elements")).withQueryParam("ids", equalTo(elementUuid.toString())).withPort(port).withHeader("userId", equalTo("chmits"))
             .willReturn(aResponse()));
 
-        stubFor(get(urlEqualTo(String.format("/v1/explore/elements/metadata?ids=%s", elementUuid))).withHeader("userId", equalTo("chmits"))
+        stubFor(get(urlPathEqualTo("/v1/explore/elements/metadata")).withQueryParam("ids", equalTo(elementUuid.toString())).withHeader("userId", equalTo("chmits"))
             .willReturn(aResponse()
                 .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .withBody(String.format("[{\"elementUuid\" : \"%s\", \"type\" : \"STUDY\", \"subdirectoriesCount\" : \"0\", \"specificMetadata\" : {\"id\" : \"%s\", \"caseFormat\" : \"IIDM\"}}]",
                         elementUuid, elementUuid))));
 
-        stubFor(get(urlEqualTo(String.format("/v1/studies/metadata?ids=%s", elementUuid))).withHeader("userId", equalTo("chmits"))
+        stubFor(get(urlPathEqualTo("/v1/studies/metadata")).withQueryParam("ids", equalTo(elementUuid.toString())).withHeader("userId", equalTo("chmits"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .withBody(String.format("[{\"id\" : \"%s\", \"caseFormat\" : \"IIDM\"}]", elementUuid))));
 
-        stubFor(get(urlEqualTo(String.format("/v1/contingency-lists/metadata?ids=%s", elementUuid))).withHeader("userId", equalTo("chmits"))
+        stubFor(get(urlPathEqualTo("/v1/contingency-lists/metadata")).withQueryParam("ids", equalTo(elementUuid.toString())).withHeader("userId", equalTo("chmits"))
             .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .withBody(String.format("[{\"id\" : \"%s\", \"type\" : \"SCRIPT\"}]", elementUuid))));
 
-        stubFor(get(urlEqualTo(String.format("/v1/filters/metadata?ids=%s", elementUuid))).withHeader("userId", equalTo("chmits"))
+        stubFor(get(urlPathEqualTo("/v1/filters/metadata")).withQueryParam("ids", equalTo(elementUuid.toString())).withHeader("userId", equalTo("chmits"))
             .willReturn(aResponse()
                 .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .withBody(String.format("[{\"id\": \"%s\", \"type\" :\"LINE\"}]", elementUuid))));
 
-        stubFor(get(urlEqualTo("/v1/root_directories")).withHeader("userId", equalTo("chmits"))
+        stubFor(get(urlPathEqualTo("/v1/root_directories")).withHeader("userId", equalTo("chmits"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .withBody("[{\"name\": \"test\"}]")));
 
-        stubFor(get(urlEqualTo("/v1/cases")).withHeader("userId", equalTo("chmits"))
+        stubFor(get(urlPathEqualTo("/v1/cases")).withHeader("userId", equalTo("chmits"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .withBody("[{\"name\": \"testCase\", \"format\" :\"XIIDM\"}, {\"name\": \"testCase2\", \"format\" :\"CGMES\"}]")));
 
-        stubFor(get(urlEqualTo("/v1/parameters")).withHeader("userId", equalTo("chmits"))
+        stubFor(get(urlPathEqualTo("/v1/parameters")).withHeader("userId", equalTo("chmits"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .withBody("[{\"theme\": \"dark\"}]")));
 
-        stubFor(get(urlEqualTo("/v1/configs")).withHeader("userId", equalTo("chmits"))
+        // Seems unused: no testToken call below ever hits this route.
+        stubFor(get(urlPathEqualTo("/v1/configs")).withHeader("userId", equalTo("chmits"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .withBody("[{\"process\": \"TEST\", \"tsos\" : [\"BE\", \"NL\"]}]")));
 
-        stubFor(get(urlEqualTo("/v1/boundaries")).withHeader("userId", equalTo("chmits"))
+        // Seems unused: no testToken call below ever hits this route.
+        stubFor(get(urlPathEqualTo("/v1/boundaries")).withHeader("userId", equalTo("chmits"))
             .willReturn(aResponse()
                 .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .withBody("[{\"name\": \"boundary1\", \"id\" :\"da47a173-22d2-47e8-8a84-aa66e2d0fafb\"}]")));
 
-        stubFor(get(urlEqualTo("/mappings")).withHeader("userId", equalTo("chmits"))
+        stubFor(get(urlPathEqualTo("/mappings")).withHeader("userId", equalTo("chmits"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .withBody("[{\"name\": \"mapping1\", \"rules\":[]}]")));
 
-        stubFor(get(urlEqualTo("/v1/reports")).withHeader("userId", equalTo("chmits"))
+        // Seems unused: no testToken call below ever hits this route.
+        stubFor(get(urlPathEqualTo("/v1/reports")).withHeader("userId", equalTo("chmits"))
             .willReturn(aResponse()
                 .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .withBody("{\"id\": \"report1\", \"reports\" :[{\"date\":\"2001:01:01T11:11\", \"report\": \"Lets Rock\" }]}")));
 
-        testToken(elementUuid, token);
+        testToken(elementUuid, token, this::authorizationHeaderAuth);
+        testToken(elementUuid, token, this::accessTokenQueryParamAuth);
+        testToken(elementUuid, token, this::accessTokenShareAuth);
         //TODO are all requests supposed to work with reference tokens from clients ?
-        testToken(elementUuid, "clientopaquetoken");
+        testToken(elementUuid, "clientopaquetoken", this::authorizationHeaderAuth);
+        testToken(elementUuid, "clientopaquetoken", this::accessTokenQueryParamAuth);
+        testToken(elementUuid, "clientopaquetoken", this::accessTokenShareAuth);
     }
 
-    private void testToken(UUID elementUuid, String token) {
-        webClient
-                .get().uri("case/v1/cases")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+    private static String appendQueryParam(String uri, String name, String value) {
+        return uri + (uri.contains("?") ? "&" : "?") + name + "=" + value;
+    }
+
+    /**
+     * Finishes setting up a request obtained from {@code webClient.get()} - called fresh at every
+     * call site in {@link #testToken} - by applying {@code uri} and the auth mode's carrier(s) for
+     * {@code token}: the URI alone (access_token query parameter), the URI and a cookie (the split
+     * access_token_share cookie + query parameter), or a header alone (Authorization).
+     */
+    @FunctionalInterface
+    private interface AuthSetup {
+        WebTestClient.RequestHeadersSpec<?> apply(WebTestClient.RequestHeadersUriSpec<?> request, String uri, String token);
+    }
+
+    /**
+     * Sets {@code uri} unmodified and carries the whole (unsplit) {@code token} in the
+     * Authorization header.
+     */
+    private WebTestClient.RequestHeadersSpec<?> authorizationHeaderAuth(WebTestClient.RequestHeadersUriSpec<?> request, String uri, String token) {
+        return request.uri(uri).header(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+    }
+
+    /**
+     * Carries the whole (unsplit) {@code token} in an access_token query parameter appended to
+     * {@code uri}.
+     */
+    private WebTestClient.RequestHeadersSpec<?> accessTokenQueryParamAuth(WebTestClient.RequestHeadersUriSpec<?> request, String uri, String token) {
+        return request.uri(appendQueryParam(uri, "access_token", token));
+    }
+
+    /**
+     * Carries {@code token} XOR-split across the AccessTokenShare cookie and an
+     * access_token_share query parameter appended to {@code uri}.
+     */
+    private WebTestClient.RequestHeadersSpec<?> accessTokenShareAuth(WebTestClient.RequestHeadersUriSpec<?> request, String uri, String token) {
+        String[] shares = splitToken(token);
+        return request.uri(appendQueryParam(uri, "access_token_share", shares[1]))
+                .cookie(ACCESS_TOKEN_SHARE_COOKIE_NAME, shares[0]);
+    }
+
+    private void testToken(UUID elementUuid, String token, AuthSetup authSetup) {
+        authSetup.apply(webClient.get(), "case/v1/cases", token)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
@@ -315,60 +396,46 @@ class TokenValidationTest {
                 .jsonPath("$[0].format").isEqualTo("XIIDM")
                 .jsonPath("$[1].format").isEqualTo("CGMES");
 
-        webClient
-                .get().uri("study/v1/studies/metadata?ids=" + elementUuid)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+        authSetup.apply(webClient.get(), "study/v1/studies/metadata?ids=" + elementUuid, token)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
                 .jsonPath("$[0].id").isEqualTo(elementUuid.toString())
                 .jsonPath("$[0].caseFormat").isEqualTo("IIDM");
 
-        webClient
-                .get().uri("actions/v1/contingency-lists/metadata?ids=" + elementUuid)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+        authSetup.apply(webClient.get(), "actions/v1/contingency-lists/metadata?ids=" + elementUuid, token)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
                 .jsonPath("$[0].id").isEqualTo(elementUuid.toString())
                 .jsonPath("$[0].type").isEqualTo("SCRIPT");
 
-        webClient
-                .get().uri("config/v1/parameters")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+        authSetup.apply(webClient.get(), "config/v1/parameters", token)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
                 .jsonPath("$[0].theme").isEqualTo("dark");
 
-        webClient
-                .get().uri("directory/v1/root_directories")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+        authSetup.apply(webClient.get(), "directory/v1/root_directories", token)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
                 .jsonPath("$[0].name").isEqualTo("test");
 
-        webClient
-                .get().uri("dynamic-mapping/mappings")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+        authSetup.apply(webClient.get(), "dynamic-mapping/mappings", token)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
                 .jsonPath("$[0].name").isEqualTo("mapping1");
 
-        webClient
-            .get().uri("filter/v1/filters/metadata?ids=" + elementUuid)
-            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+        authSetup.apply(webClient.get(), "filter/v1/filters/metadata?ids=" + elementUuid, token)
             .exchange()
             .expectStatus().isOk()
             .expectBody()
             .jsonPath("$[0].id").isEqualTo(elementUuid.toString())
             .jsonPath("$[0].type").isEqualTo("LINE");
 
-        webClient
-            .get().uri("explore/v1/explore/elements/metadata?ids=" + elementUuid)
-            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+        authSetup.apply(webClient.get(), "explore/v1/explore/elements/metadata?ids=" + elementUuid, token)
             .exchange()
             .expectStatus().isOk()
             .expectBody()
@@ -389,10 +456,179 @@ class TokenValidationTest {
                 .withStatus(101)
                 .withStatusMessage("Switching Protocols")));
 
-        testWebsocket("study-notification");
-        testWebsocket("config-notification");
-        testWebsocket("merge-notification");
-        testWebsocket("directory-notification");
+        // Note: Not sure if it's very useful to test all these routes
+        testWebsocket("study-notification", false, token);
+        testWebsocket("config-notification", false, token);
+        testWebsocket("merge-notification", false, token);
+        testWebsocket("directory-notification", false, token);
+        testWebsocket("study-notification", true, token);
+        testWebsocket("config-notification", true, token);
+        testWebsocket("merge-notification", true, token);
+        testWebsocket("directory-notification", true, token);
+        testWebsocket("study-notification", false, "clientopaquetoken");
+        testWebsocket("config-notification", false, "clientopaquetoken");
+        testWebsocket("merge-notification", false, "clientopaquetoken");
+        testWebsocket("directory-notification", false, "clientopaquetoken");
+        testWebsocket("study-notification", true, "clientopaquetoken");
+        testWebsocket("config-notification", true, "clientopaquetoken");
+        testWebsocket("merge-notification", true, "clientopaquetoken");
+        testWebsocket("directory-notification", true, "clientopaquetoken");
+    }
+
+    @Test
+    void testLoneAccessTokenShareChannelIsAlwaysRejected() {
+        initStubForJwk();
+        // Needed here (unlike most other tests in this class): the verify(0, ...) below is an
+        // exact-count check, so it would be broken by leftover /introspection requests left in
+        // WireMock's journal by earlier tests in this class (e.g. testAudienceValidation),
+        // since the WireMock server/journal is shared across all @Test methods in this class.
+        resetAllRequests();
+
+        stubFor(get(urlPathEqualTo("/v1/cases"))
+                .willReturn(aResponse()
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("[{\"name\": \"testCase\", \"format\" :\"XIIDM\"}]")));
+
+        String[] shares = splitToken(token);
+
+        // Cookie share alone, no access_token_share query param companion: rejected outright,
+        // never even reaches token validation - a lone share is never usable by itself.
+        webClient
+                .get().uri("case/v1/cases")
+                .cookie(ACCESS_TOKEN_SHARE_COOKIE_NAME, shares[0])
+                .exchange()
+                .expectStatus().isUnauthorized();
+
+        // Query share alone, no AccessTokenShare cookie companion: same.
+        webClient
+                .get().uri("case/v1/cases?access_token_share=" + shares[1])
+                .exchange()
+                .expectStatus().isUnauthorized();
+
+        // Even a genuinely valid whole token alone in the AccessTokenShare cookie (no query
+        // companion) is rejected: unlike the deprecated whole-token-in-cookie mode, this cookie
+        // is never usable by itself, precisely so that it can't be replayed as ambient authority
+        // by a cross-site request an attacker's page could trigger (CSRF).
+        webClient
+                .get().uri("case/v1/cases")
+                .cookie(ACCESS_TOKEN_SHARE_COOKIE_NAME, token)
+                .exchange()
+                .expectStatus().isUnauthorized();
+
+        // None of the above ever reached opaque-token introspection: they're all rejected
+        // upfront by the priority chain in filter(), before any token validation is attempted.
+        verify(0, postRequestedFor(urlEqualTo("/introspection")));
+    }
+
+    @Test
+    void testSplitTokenRejectsMismatchedShareLengths() {
+        initStubForJwk();
+
+        stubFor(get(urlPathEqualTo("/v1/cases"))
+                .willReturn(aResponse()
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("[{\"name\": \"testCase\", \"format\" :\"XIIDM\"}]")));
+
+        String[] shares = splitToken(token);
+        // Truncate the query share by one byte so its decoded length no longer matches the
+        // cookie share's: recombination fails and the gateway rejects outright - unlike the
+        // access_token query parameter, access_token_share is never meaningful as a whole token
+        // by itself, so there's no fallback to attempt.
+        byte[] xoredBytes = Base64.getUrlDecoder().decode(shares[1]);
+        String truncatedQueryShare = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(Arrays.copyOf(xoredBytes, xoredBytes.length - 1));
+
+        webClient
+                .get().uri("case/v1/cases?access_token_share=" + truncatedQueryShare)
+                .cookie(ACCESS_TOKEN_SHARE_COOKIE_NAME, shares[0])
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void testSplitTokenRejectsNonBase64AccessTokenShare() {
+        initStubForJwk();
+
+        stubFor(get(urlPathEqualTo("/v1/cases"))
+                .willReturn(aResponse()
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("[{\"name\": \"testCase\", \"format\" :\"XIIDM\"}]")));
+
+        String[] shares = splitToken(token);
+        // "!" isn't part of the base64url alphabet: Base64.getUrlDecoder() throws
+        // IllegalArgumentException, exercising recoverSplitToken's catch block itself - unlike
+        // testSplitTokenRejectsMismatchedShareLengths above, whose truncated share still decodes
+        // fine and instead exercises the decoded-length mismatch check.
+        webClient
+                .get().uri("case/v1/cases?access_token_share=not-a-valid-base64!!!")
+                .cookie(ACCESS_TOKEN_SHARE_COOKIE_NAME, shares[0])
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void testSplitTokenSharesRecombineRegardlessOfOrder() {
+        initStubForJwk();
+
+        stubFor(get(urlPathEqualTo("/v1/cases")).withHeader("userId", equalTo("chmits"))
+                .willReturn(aResponse()
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("[{\"name\": \"testCase\", \"format\" :\"XIIDM\"}]")));
+
+        // XOR is commutative, so recombination succeeds the same way whichever share ends up in
+        // the cookie and whichever ends up in the query parameter: swapping them still recovers
+        // the same token.
+        String[] shares = splitToken(token);
+
+        webClient
+                .get().uri("case/v1/cases?access_token_share=" + shares[1])
+                .cookie(ACCESS_TOKEN_SHARE_COOKIE_NAME, shares[0])
+                .exchange()
+                .expectStatus().isOk();
+
+        webClient
+                .get().uri("case/v1/cases?access_token_share=" + shares[0])
+                .cookie(ACCESS_TOKEN_SHARE_COOKIE_NAME, shares[1])
+                .exchange()
+                .expectStatus().isOk();
+    }
+
+    @Test
+    void testAccessTokenQueryParamTakesPriorityOverAccessTokenShares() {
+        initStubForJwk();
+
+        stubFor(get(urlPathEqualTo("/v1/cases")).withHeader("userId", equalTo("chmits"))
+                .willReturn(aResponse()
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("[{\"name\": \"testCase\", \"format\" :\"XIIDM\"}]")));
+
+        // access_token (whole token, priority 2) is checked - and used - before the
+        // AccessTokenShare/access_token_share pair (priority 3) is even looked at, so garbage in
+        // the latter never gets in the way.
+        webClient
+                .get().uri("case/v1/cases?access_token=" + token)
+                .cookie(ACCESS_TOKEN_SHARE_COOKIE_NAME, "not-a-valid-share")
+                .exchange()
+                .expectStatus().isOk();
+    }
+
+    @Test
+    void testAuthorizationHeaderTakesPriorityOverQueryAndShares() {
+        initStubForJwk();
+
+        stubFor(get(urlEqualTo("/v1/cases")).withHeader("userId", equalTo("chmits"))
+                .willReturn(aResponse()
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("[{\"name\": \"testCase\", \"format\" :\"XIIDM\"}]")));
+
+        // A garbage access_token and share cookie must be ignored when a valid Authorization
+        // header is also present.
+        webClient
+                .get().uri("case/v1/cases?access_token=not-a-valid-token")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .cookie(ACCESS_TOKEN_SHARE_COOKIE_NAME, "not-a-valid-share")
+                .exchange()
+                .expectStatus().isOk();
     }
 
     @Test


### PR DESCRIPTION
## PR Summary
This allows to avoid both CSRF attacks (from cookies) and token leaks (from logs), retaining the bearer token behavior controlled by the oidc provider which decides who it gives token to (no need to restrict origin URLs in the gateway for csrf protection for example)

As part of the test refactoring to test this new mode, also add more coverage for previous modes in all cases. Previously it was only query string for websocket and Authorization: Bearer for everything else. But the query string mode is useful for normal api calls, for exemple for native browser downloads (or more rarely, native browser images/css/...)




