### PR TITLE
Add first-frame WebSocket auth proxy endpoint (/ws-dataauth/** -> loc…

### DIFF
--- a/src/main/java/org/gridsuite/gateway/ws/WsDataAuthConfig.java
+++ b/src/main/java/org/gridsuite/gateway/ws/WsDataAuthConfig.java
@@ -1,0 +1,43 @@
+/*
+  Copyright (c) 2026, RTE (http://www.rte-france.com)
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.gateway.ws;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
+
+import java.util.Map;
+
+/**
+ * Registers the {@link WsDataAuthProxyHandler} on {@code /ws-dataauth/**} with a handler
+ * mapping order of {@code -1}, i.e. before Spring Cloud Gateway's
+ * {@code RoutePredicateHandlerMapping} (order {@code 1}). All other paths are unaffected
+ * and continue to be handled by the normal gateway routes.
+ *
+ * <p>NOTE: gateway global pre-filters (e.g. {@code TokenValidatorGlobalPreFilter}) only apply
+ * to gateway routes; they are intentionally bypassed for this endpoint. Authentication is
+ * delegated to the upstream service which receives the token from the first WebSocket frame
+ * as an {@code Authorization: Bearer} header.</p>
+ *
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
+@Configuration
+@EnableConfigurationProperties(WsDataAuthProperties.class)
+@ConditionalOnProperty(prefix = "ws-dataauth", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class WsDataAuthConfig {
+
+    @Bean
+    public HandlerMapping wsDataAuthHandlerMapping(WsDataAuthProxyHandler handler) {
+        SimpleUrlHandlerMapping mapping = new SimpleUrlHandlerMapping(
+                Map.of(WsDataAuthProperties.PATH_PREFIX + "/**", handler));
+        mapping.setOrder(-1); // before RoutePredicateHandlerMapping (order 1)
+        return mapping;
+    }
+}

--- a/src/main/java/org/gridsuite/gateway/ws/WsDataAuthProperties.java
+++ b/src/main/java/org/gridsuite/gateway/ws/WsDataAuthProperties.java
@@ -1,0 +1,39 @@
+/*
+  Copyright (c) 2026, RTE (http://www.rte-france.com)
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.gateway.ws;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * Configuration for the first-frame WebSocket authentication proxy endpoint.
+ *
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "ws-dataauth")
+public class WsDataAuthProperties {
+
+    /** Path prefix under which the proxy endpoint is exposed. */
+    public static final String PATH_PREFIX = "/ws-dataauth";
+
+    /** Whether the endpoint is enabled. */
+    private boolean enabled = true;
+
+    /** Upstream port on localhost to which connections are proxied. */
+    private int upstreamPort = 80;
+
+    /** Maximum time to wait for the first (token) frame from the client. */
+    private Duration authTimeout = Duration.ofSeconds(5);
+
+    /** Maximum accepted size, in bytes, of the first (token) frame. */
+    private int maxTokenBytes = 8192;
+}

--- a/src/main/java/org/gridsuite/gateway/ws/WsDataAuthProperties.java
+++ b/src/main/java/org/gridsuite/gateway/ws/WsDataAuthProperties.java
@@ -28,9 +28,6 @@ public class WsDataAuthProperties {
     /** Whether the endpoint is enabled. */
     private boolean enabled = true;
 
-    /** Upstream port on localhost to which connections are proxied. */
-    private int upstreamPort = 80;
-
     /** Maximum time to wait for the first (token) frame from the client. */
     private Duration authTimeout = Duration.ofSeconds(5);
 

--- a/src/main/java/org/gridsuite/gateway/ws/WsDataAuthProxyHandler.java
+++ b/src/main/java/org/gridsuite/gateway/ws/WsDataAuthProxyHandler.java
@@ -1,0 +1,145 @@
+/*
+  Copyright (c) 2026, RTE (http://www.rte-france.com)
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.gateway.ws;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.socket.CloseStatus;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
+
+/**
+ * WebSocket proxy implementing "first-message authentication" to work around the browser
+ * limitation of not being able to set an {@code Authorization} header on WebSocket connections.
+ *
+ * <p>Behavior:</p>
+ * <ol>
+ *   <li>Accepts the client WebSocket on {@code /ws-dataauth/**}.</li>
+ *   <li>Reads the FIRST text frame and treats it as an opaque bearer token (no validation).
+ *       The frame is consumed and never forwarded upstream. A timeout and size limit apply.</li>
+ *   <li>Dials a NEW WebSocket to {@code ws://localhost:<upstream-port>} with the
+ *       {@code /ws-dataauth} prefix stripped ({@code /ws-dataauth/foo/bar?x=y} →
+ *       {@code /foo/bar?x=y}), setting {@code Authorization: Bearer <token>} on the handshake.</li>
+ *   <li>Transparently relays all subsequent frames bidirectionally, preserving frame type.</li>
+ *   <li>Propagates upstream handshake failures and close statuses to the client.</li>
+ * </ol>
+ *
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
+@Component
+public class WsDataAuthProxyHandler implements WebSocketHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WsDataAuthProxyHandler.class);
+
+    private static final Pattern PRINTABLE_ASCII = Pattern.compile("[\\x20-\\x7E]+");
+
+    private static final int MAX_CLOSE_REASON_BYTES = 123;
+
+    private final WsDataAuthProperties properties;
+
+    private final ReactorNettyWebSocketClient client = new ReactorNettyWebSocketClient();
+
+    public WsDataAuthProxyHandler(WsDataAuthProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public Mono<Void> handle(WebSocketSession clientSession) {
+        return clientSession.receive()
+            .next() // frame #1: the token — consumed here, never forwarded upstream
+            .timeout(properties.getAuthTimeout())
+            .flatMap(frame -> proxy(clientSession, frame.getPayloadAsText()))
+            .onErrorResume(TimeoutException.class,
+                e -> clientSession.close(new CloseStatus(1008, "auth timeout")))
+            .onErrorResume(e -> {
+                LOGGER.debug("ws-dataauth client session error", e);
+                return clientSession.close(new CloseStatus(1011, truncateReason("proxy error: " + e.getMessage())));
+            });
+    }
+
+    private Mono<Void> proxy(WebSocketSession clientSession, String token) {
+        if (token.isEmpty() || token.getBytes(StandardCharsets.UTF_8).length > properties.getMaxTokenBytes()
+                || !PRINTABLE_ASCII.matcher(token).matches()) {
+            // reject empty/oversized tokens and any characters outside printable ASCII
+            // to prevent HTTP header injection on the upstream handshake
+            return clientSession.close(new CloseStatus(1008, "invalid token frame"));
+        }
+
+        URI upstreamUri;
+        try {
+            upstreamUri = buildUpstreamUri(clientSession.getHandshakeInfo().getUri());
+        } catch (URISyntaxException e) {
+            return clientSession.close(new CloseStatus(1008, "invalid path"));
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token); // verbatim copy of frame #1, no validation by design
+
+        LOGGER.debug("ws-dataauth proxying to {}", upstreamUri);
+
+        return client.execute(upstreamUri, headers, upstreamSession ->
+                Mono.zip(
+                    upstreamSession.send(retained(clientSession.receive())),
+                    clientSession.send(retained(upstreamSession.receive()))
+                ).then())
+            .onErrorResume(e -> {
+                LOGGER.debug("ws-dataauth upstream failure for {}", upstreamUri, e);
+                return clientSession.close(new CloseStatus(1008,
+                        truncateReason("upstream rejected/failed: " + e.getMessage())));
+            });
+    }
+
+    /**
+     * Retains relayed frame payloads so they survive until the outbound write completes, and
+     * releases any frame discarded on cancellation (e.g. when {@code Mono.zip} cancels one relay
+     * direction because the other terminated) to avoid leaking pooled Netty buffers.
+     */
+    private static Flux<WebSocketMessage> retained(Flux<WebSocketMessage> in) {
+        return in.map(f -> new WebSocketMessage(f.getType(), f.getPayload().retain()))
+                 .doOnDiscard(WebSocketMessage.class, m -> DataBufferUtils.release(m.getPayload()));
+    }
+
+    /**
+     * Maps {@code /ws-dataauth/foo/bar?x=y} to {@code ws://localhost:<upstream-port>/foo/bar?x=y}.
+     */
+    private URI buildUpstreamUri(URI clientUri) throws URISyntaxException {
+        String path = clientUri.getRawPath();
+        String stripped = path.startsWith(WsDataAuthProperties.PATH_PREFIX)
+                ? path.substring(WsDataAuthProperties.PATH_PREFIX.length())
+                : path;
+        if (stripped.isEmpty()) {
+            stripped = "/";
+        }
+        String query = clientUri.getRawQuery();
+        return new URI("ws", null, "localhost", properties.getUpstreamPort(),
+                stripped, null, null).resolve(query != null ? stripped + "?" + query : stripped)
+            .isAbsolute()
+                ? new URI("ws://localhost:" + properties.getUpstreamPort() + stripped + (query != null ? "?" + query : ""))
+                : new URI("ws://localhost:" + properties.getUpstreamPort() + stripped + (query != null ? "?" + query : ""));
+    }
+
+    private static String truncateReason(String reason) {
+        byte[] bytes = reason.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length <= MAX_CLOSE_REASON_BYTES) {
+            return reason;
+        }
+        return new String(bytes, 0, MAX_CLOSE_REASON_BYTES, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/org/gridsuite/gateway/ws/WsDataAuthProxyHandler.java
+++ b/src/main/java/org/gridsuite/gateway/ws/WsDataAuthProxyHandler.java
@@ -6,6 +6,7 @@
  */
 package org.gridsuite.gateway.ws;
 
+import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.buffer.DataBufferUtils;
@@ -20,26 +21,16 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 /**
- * WebSocket proxy implementing "first-message authentication" to work around the browser
- * limitation of not being able to set an {@code Authorization} header on WebSocket connections.
+ * WebSocket proxy implementing first-message authentication for browsers, which cannot set an
+ * authorization header during the WebSocket handshake.
  *
- * <p>Behavior:</p>
- * <ol>
- *   <li>Accepts the client WebSocket on {@code /ws-dataauth/**}.</li>
- *   <li>Reads the FIRST text frame and treats it as an opaque bearer token (no validation).
- *       The frame is consumed and never forwarded upstream. A timeout and size limit apply.</li>
- *   <li>Dials a NEW WebSocket to {@code ws://localhost:<upstream-port>} with the
- *       {@code /ws-dataauth} prefix stripped ({@code /ws-dataauth/foo/bar?x=y} →
- *       {@code /foo/bar?x=y}), setting {@code Authorization: Bearer <token>} on the handshake.</li>
- *   <li>Transparently relays all subsequent frames bidirectionally, preserving frame type.</li>
- *   <li>Propagates upstream handshake failures and close statuses to the client.</li>
- * </ol>
+ * <p>This handler bypasses the normal Spring Cloud Gateway route pipeline and its global
+ * pre-filters by design. The upstream service is responsible for authenticating the token.</p>
  *
  * @author Jon Harper <jon.harper at rte-france.com>
  */
@@ -62,84 +53,116 @@ public class WsDataAuthProxyHandler implements WebSocketHandler {
 
     @Override
     public Mono<Void> handle(WebSocketSession clientSession) {
-        return clientSession.receive()
-            .next() // frame #1: the token — consumed here, never forwarded upstream
-            .timeout(properties.getAuthTimeout())
-            .flatMap(frame -> proxy(clientSession, frame.getPayloadAsText()))
-            .onErrorResume(TimeoutException.class,
-                e -> clientSession.close(new CloseStatus(1008, "auth timeout")))
+        AtomicBoolean firstFrameReceived = new AtomicBoolean();
+        AtomicBoolean authTimeoutStarted = new AtomicBoolean();
+        Mono<Void> proxy = clientSession.receive()
+            .switchOnFirst((signal, frames) -> {
+                firstFrameReceived.set(true);
+                if (!signal.hasValue()) {
+                    if (signal.getThrowable() != null) {
+                        return Flux.error(signal.getThrowable());
+                    }
+                    return authTimeoutStarted.get() ? Flux.never() : Flux.empty();
+                }
+                WebSocketMessage tokenFrame = signal.get();
+                if (tokenFrame.getType() != WebSocketMessage.Type.TEXT) {
+                    return closeWithPolicyViolation(clientSession, "invalid token frame").thenMany(Flux.empty());
+                }
+                return proxy(clientSession, frames.skip(1), tokenFrame.getPayloadAsText()).thenMany(Flux.empty());
+            })
+            .then()
             .onErrorResume(e -> {
                 LOGGER.debug("ws-dataauth client session error", e);
-                return clientSession.close(new CloseStatus(1011, truncateReason("proxy error: " + e.getMessage())));
+                return closeWithServerError(clientSession, "proxy error");
             });
+        Mono<Void> authTimeout = Mono.delay(properties.getAuthTimeout())
+            .flatMap(ignored -> firstFrameReceived.get()
+                    ? Mono.never()
+                    : closeAfterAuthTimeout(clientSession, authTimeoutStarted));
+
+        return Mono.firstWithSignal(proxy, authTimeout);
     }
 
-    private Mono<Void> proxy(WebSocketSession clientSession, String token) {
+    private static Mono<Void> closeAfterAuthTimeout(WebSocketSession session, AtomicBoolean authTimeoutStarted) {
+        authTimeoutStarted.set(true);
+        return closeWithPolicyViolation(session, "auth timeout");
+    }
+
+    private Mono<Void> proxy(WebSocketSession clientSession, Flux<WebSocketMessage> clientFrames, String token) {
         if (token.isEmpty() || token.getBytes(StandardCharsets.UTF_8).length > properties.getMaxTokenBytes()
                 || !PRINTABLE_ASCII.matcher(token).matches()) {
-            // reject empty/oversized tokens and any characters outside printable ASCII
-            // to prevent HTTP header injection on the upstream handshake
-            return clientSession.close(new CloseStatus(1008, "invalid token frame"));
+            return closeWithPolicyViolation(clientSession, "invalid token frame");
         }
 
-        URI upstreamUri;
-        try {
-            upstreamUri = buildUpstreamUri(clientSession.getHandshakeInfo().getUri());
-        } catch (URISyntaxException e) {
-            return clientSession.close(new CloseStatus(1008, "invalid path"));
-        }
-
+        URI upstreamUri = buildUpstreamUri(clientSession.getHandshakeInfo().getUri());
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(token); // verbatim copy of frame #1, no validation by design
+        headers.setBearerAuth(token);
 
         LOGGER.debug("ws-dataauth proxying to {}", upstreamUri);
 
-        return client.execute(upstreamUri, headers, upstreamSession ->
-                Mono.zip(
-                    upstreamSession.send(retained(clientSession.receive())),
-                    clientSession.send(retained(upstreamSession.receive()))
-                ).then())
+        return client.execute(upstreamUri, headers,
+                upstreamSession -> relay(clientSession, clientFrames, upstreamSession))
+            .onErrorResume(WebSocketClientHandshakeException.class, e -> {
+                LOGGER.debug("ws-dataauth upstream handshake rejected for {}", upstreamUri, e);
+                return closeWithPolicyViolation(clientSession, "upstream handshake rejected");
+            })
             .onErrorResume(e -> {
                 LOGGER.debug("ws-dataauth upstream failure for {}", upstreamUri, e);
-                return clientSession.close(new CloseStatus(1008,
-                        truncateReason("upstream rejected/failed: " + e.getMessage())));
+                return closeWithServerError(clientSession, "upstream connection failed");
             });
+    }
+
+    private static Mono<Void> relay(WebSocketSession clientSession, Flux<WebSocketMessage> clientFrames,
+                                    WebSocketSession upstreamSession) {
+        return Mono.zip(
+                upstreamSession.send(retained(clientFrames)),
+                clientSession.send(retained(upstreamSession.receive())))
+            .then();
     }
 
     /**
      * Retains relayed frame payloads so they survive until the outbound write completes, and
-     * releases any frame discarded on cancellation (e.g. when {@code Mono.zip} cancels one relay
-     * direction because the other terminated) to avoid leaking pooled Netty buffers.
+     * releases any frame discarded on cancellation to avoid leaking pooled Netty buffers.
      */
     private static Flux<WebSocketMessage> retained(Flux<WebSocketMessage> in) {
-        return in.map(f -> new WebSocketMessage(f.getType(), f.getPayload().retain()))
+        return in.map(f -> new WebSocketMessage(f.getType(), DataBufferUtils.retain(f.getPayload())))
                  .doOnDiscard(WebSocketMessage.class, m -> DataBufferUtils.release(m.getPayload()));
     }
 
-    /**
-     * Maps {@code /ws-dataauth/foo/bar?x=y} to {@code ws://localhost:<upstream-port>/foo/bar?x=y}.
-     */
-    private URI buildUpstreamUri(URI clientUri) throws URISyntaxException {
-        String path = clientUri.getRawPath();
-        String stripped = path.startsWith(WsDataAuthProperties.PATH_PREFIX)
-                ? path.substring(WsDataAuthProperties.PATH_PREFIX.length())
-                : path;
-        if (stripped.isEmpty()) {
-            stripped = "/";
+    private URI buildUpstreamUri(URI clientUri) {
+        String strippedPath = clientUri.getRawPath().substring(WsDataAuthProperties.PATH_PREFIX.length());
+        if (strippedPath.isEmpty()) {
+            strippedPath = "/";
         }
         String query = clientUri.getRawQuery();
-        return new URI("ws", null, "localhost", properties.getUpstreamPort(),
-                stripped, null, null).resolve(query != null ? stripped + "?" + query : stripped)
-            .isAbsolute()
-                ? new URI("ws://localhost:" + properties.getUpstreamPort() + stripped + (query != null ? "?" + query : ""))
-                : new URI("ws://localhost:" + properties.getUpstreamPort() + stripped + (query != null ? "?" + query : ""));
+        return URI.create("ws://localhost:" + properties.getUpstreamPort() + strippedPath
+                + (query != null ? "?" + query : ""));
+    }
+
+    private static Mono<Void> closeWithPolicyViolation(WebSocketSession session, String reason) {
+        return session.close(new CloseStatus(1008, truncateReason(reason)));
+    }
+
+    private static Mono<Void> closeWithServerError(WebSocketSession session, String reason) {
+        return session.close(new CloseStatus(1011, truncateReason(reason)));
     }
 
     private static String truncateReason(String reason) {
-        byte[] bytes = reason.getBytes(StandardCharsets.UTF_8);
-        if (bytes.length <= MAX_CLOSE_REASON_BYTES) {
+        if (reason.getBytes(StandardCharsets.UTF_8).length <= MAX_CLOSE_REASON_BYTES) {
             return reason;
         }
-        return new String(bytes, 0, MAX_CLOSE_REASON_BYTES, StandardCharsets.UTF_8);
+        StringBuilder truncated = new StringBuilder();
+        int byteCount = 0;
+        for (int index = 0; index < reason.length();) {
+            int codePoint = reason.codePointAt(index);
+            int codePointBytes = new String(Character.toChars(codePoint)).getBytes(StandardCharsets.UTF_8).length;
+            if (byteCount + codePointBytes > MAX_CLOSE_REASON_BYTES) {
+                break;
+            }
+            truncated.appendCodePoint(codePoint);
+            byteCount += codePointBytes;
+            index += Character.charCount(codePoint);
+        }
+        return truncated.toString();
     }
 }

--- a/src/main/java/org/gridsuite/gateway/ws/WsDataAuthProxyHandler.java
+++ b/src/main/java/org/gridsuite/gateway/ws/WsDataAuthProxyHandler.java
@@ -9,6 +9,7 @@ package org.gridsuite.gateway.ws;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.context.WebServerApplicationContext;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -45,10 +46,13 @@ public class WsDataAuthProxyHandler implements WebSocketHandler {
 
     private final WsDataAuthProperties properties;
 
+    private final WebServerApplicationContext applicationContext;
+
     private final ReactorNettyWebSocketClient client = new ReactorNettyWebSocketClient();
 
-    public WsDataAuthProxyHandler(WsDataAuthProperties properties) {
+    public WsDataAuthProxyHandler(WsDataAuthProperties properties, WebServerApplicationContext applicationContext) {
         this.properties = properties;
+        this.applicationContext = applicationContext;
     }
 
     @Override
@@ -135,7 +139,7 @@ public class WsDataAuthProxyHandler implements WebSocketHandler {
             strippedPath = "/";
         }
         String query = clientUri.getRawQuery();
-        return URI.create("ws://localhost:" + properties.getUpstreamPort() + strippedPath
+        return URI.create("ws://localhost:" + applicationContext.getWebServer().getPort() + strippedPath
                 + (query != null ? "?" + query : ""));
     }
 

--- a/src/test/java/org/gridsuite/gateway/ws/WsDataAuthProxyTest.java
+++ b/src/test/java/org/gridsuite/gateway/ws/WsDataAuthProxyTest.java
@@ -1,0 +1,134 @@
+/*
+  Copyright (c) 2026, RTE (http://www.rte-france.com)
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.gateway.ws;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for the /ws-dataauth first-frame authentication proxy.
+ *
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"ws-dataauth.auth-timeout=2s"})
+class WsDataAuthProxyTest {
+
+    private static DisposableServer upstream;
+
+    private static final List<String> UPSTREAM_AUTH_HEADERS = new CopyOnWriteArrayList<>();
+    private static final List<String> UPSTREAM_PATHS = new CopyOnWriteArrayList<>();
+    private static final ConcurrentLinkedQueue<String> UPSTREAM_RECEIVED = new ConcurrentLinkedQueue<>();
+
+    @LocalServerPort
+    private int gatewayPort;
+
+    @BeforeAll
+    static void startUpstream() {
+        upstream = HttpServer.create()
+            .host("localhost")
+            .port(0)
+            .route(routes -> routes.ws("/foo/bar", (in, out) -> {
+                UPSTREAM_AUTH_HEADERS.add(in.headers().get(HttpHeaders.AUTHORIZATION));
+                // echo every received text frame back, prefixed
+                return out.sendString(in.receive().asString()
+                        .doOnNext(UPSTREAM_RECEIVED::add)
+                        .map(s -> "echo:" + s));
+            }))
+            .bindNow();
+    }
+
+    @AfterAll
+    static void stopUpstream() {
+        upstream.disposeNow();
+    }
+
+    @DynamicPropertySource
+    static void wsProps(DynamicPropertyRegistry registry) {
+        registry.add("ws-dataauth.upstream-port", () -> upstream.port());
+    }
+
+    @Test
+    void tokenIsCopiedToAuthorizationHeaderAndNotForwarded() {
+        ReactorNettyWebSocketClient client = new ReactorNettyWebSocketClient();
+        List<String> received = new CopyOnWriteArrayList<>();
+
+        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/foo/bar"),
+            session -> {
+                Mono<Void> send = session.send(Flux.just(
+                        session.textMessage("my-secret-token"),   // frame #1: token
+                        session.textMessage("hello")));            // frame #2: payload
+                Mono<Void> receive = session.receive()
+                        .map(WebSocketMessage::getPayloadAsText)
+                        .doOnNext(received::add)
+                        .take(1)
+                        .then();
+                return send.and(receive);
+            })
+            .block(Duration.ofSeconds(10));
+
+        assertThat(UPSTREAM_AUTH_HEADERS).contains("Bearer my-secret-token");
+        assertThat(UPSTREAM_RECEIVED).contains("hello");
+        assertThat(UPSTREAM_RECEIVED).doesNotContain("my-secret-token");
+        assertThat(received).containsExactly("echo:hello");
+    }
+
+    @Test
+    void invalidTokenIsRejected() {
+        ReactorNettyWebSocketClient client = new ReactorNettyWebSocketClient();
+
+        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/foo/bar"),
+            session -> session.send(Flux.just(session.textMessage("bad\r\ntoken")))
+                .then(session.closeStatus()
+                    .doOnNext(status -> assertThat(status.getCode()).isEqualTo(1008))
+                    .then()))
+            .block(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void authTimeoutClosesConnection() {
+        ReactorNettyWebSocketClient client = new ReactorNettyWebSocketClient();
+
+        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/foo/bar"),
+            session -> session.closeStatus()
+                .doOnNext(status -> assertThat(status.getCode()).isEqualTo(1008))
+                .then())
+            .block(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void unknownUpstreamPathClosesWithUpstreamError() {
+        ReactorNettyWebSocketClient client = new ReactorNettyWebSocketClient();
+
+        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/does/not/exist"),
+            session -> session.send(Flux.just(session.textMessage("tok")))
+                .then(session.closeStatus()
+                    .doOnNext(status -> assertThat(status.getCode()).isEqualTo(1008))
+                    .then()))
+            .block(Duration.ofSeconds(10));
+    }
+}

--- a/src/test/java/org/gridsuite/gateway/ws/WsDataAuthProxyTest.java
+++ b/src/test/java/org/gridsuite/gateway/ws/WsDataAuthProxyTest.java
@@ -9,8 +9,8 @@ package org.gridsuite.gateway.ws;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -52,12 +52,12 @@ class WsDataAuthProxyTest {
         upstream = HttpServer.create()
             .host("localhost")
             .port(0)
-            .route(routes -> routes.ws("/foo/bar", (in, out) -> {
-                UPSTREAM_AUTH_HEADERS.add(in.headers().get(HttpHeaders.AUTHORIZATION));
-                // echo every received text frame back, prefixed
-                return out.sendString(in.receive().asString()
-                        .doOnNext(UPSTREAM_RECEIVED::add)
-                        .map(s -> "echo:" + s));
+            .route(routes -> routes.route(request -> request.uri().startsWith("/foo/bar"), (request, response) -> {
+                UPSTREAM_AUTH_HEADERS.add(request.requestHeaders().get(HttpHeaders.AUTHORIZATION));
+                UPSTREAM_PATHS.add(request.uri());
+                return response.sendWebsocket((in, out) -> out.sendString(in.receive().asString()
+                    .doOnNext(UPSTREAM_RECEIVED::add)
+                    .map(s -> "echo:" + s)));
             }))
             .bindNow();
     }
@@ -77,7 +77,7 @@ class WsDataAuthProxyTest {
         ReactorNettyWebSocketClient client = new ReactorNettyWebSocketClient();
         List<String> received = new CopyOnWriteArrayList<>();
 
-        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/foo/bar"),
+        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/foo/bar?x=y"),
             session -> {
                 Mono<Void> send = session.send(Flux.just(
                         session.textMessage("my-secret-token"),   // frame #1: token
@@ -92,6 +92,7 @@ class WsDataAuthProxyTest {
             .block(Duration.ofSeconds(10));
 
         assertThat(UPSTREAM_AUTH_HEADERS).contains("Bearer my-secret-token");
+        assertThat(UPSTREAM_PATHS).contains("/foo/bar?x=y");
         assertThat(UPSTREAM_RECEIVED).contains("hello");
         assertThat(UPSTREAM_RECEIVED).doesNotContain("my-secret-token");
         assertThat(received).containsExactly("echo:hello");

--- a/src/test/java/org/gridsuite/gateway/ws/WsDataAuthProxyTest.java
+++ b/src/test/java/org/gridsuite/gateway/ws/WsDataAuthProxyTest.java
@@ -6,16 +6,22 @@
  */
 package org.gridsuite.gateway.ws;
 
+import org.gridsuite.gateway.filters.TokenValidatorGlobalPreFilter;
+import org.gridsuite.gateway.filters.UserAdminControlGlobalPreFilter;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.reactive.socket.WebSocketMessage;
 import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.DisposableServer;
@@ -28,6 +34,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 
 /**
  * Integration test for the /ws-dataauth first-frame authentication proxy.
@@ -35,7 +43,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Jon Harper <jon.harper at rte-france.com>
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = {"ws-dataauth.auth-timeout=2s"})
+        properties = {"ws-dataauth.auth-timeout=2s",
+            "gridsuite.services.study-server.base-uri=http://localhost:${test-upstream-port}"})
 class WsDataAuthProxyTest {
 
     private static DisposableServer upstream;
@@ -46,6 +55,12 @@ class WsDataAuthProxyTest {
 
     @LocalServerPort
     private int gatewayPort;
+
+    @MockitoBean
+    private TokenValidatorGlobalPreFilter tokenValidatorGlobalPreFilter;
+
+    @MockitoBean
+    private UserAdminControlGlobalPreFilter userAdminControlGlobalPreFilter;
 
     @BeforeAll
     static void startUpstream() {
@@ -69,7 +84,17 @@ class WsDataAuthProxyTest {
 
     @DynamicPropertySource
     static void wsProps(DynamicPropertyRegistry registry) {
-        registry.add("ws-dataauth.upstream-port", () -> upstream.port());
+        registry.add("test-upstream-port", () -> upstream.port());
+    }
+
+    @BeforeEach
+    void bypassTokenValidationForMockUpstream() {
+        doAnswer(invocation -> invocation.getArgument(1, GatewayFilterChain.class)
+                .filter(invocation.getArgument(0, ServerWebExchange.class)))
+            .when(tokenValidatorGlobalPreFilter).filter(any(), any());
+        doAnswer(invocation -> invocation.getArgument(1, GatewayFilterChain.class)
+                .filter(invocation.getArgument(0, ServerWebExchange.class)))
+            .when(userAdminControlGlobalPreFilter).filter(any(), any());
     }
 
     @Test
@@ -77,7 +102,7 @@ class WsDataAuthProxyTest {
         ReactorNettyWebSocketClient client = new ReactorNettyWebSocketClient();
         List<String> received = new CopyOnWriteArrayList<>();
 
-        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/foo/bar?x=y"),
+        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/study/foo/bar?x=y"),
             session -> {
                 Mono<Void> send = session.send(Flux.just(
                         session.textMessage("my-secret-token"),   // frame #1: token
@@ -102,7 +127,7 @@ class WsDataAuthProxyTest {
     void invalidTokenIsRejected() {
         ReactorNettyWebSocketClient client = new ReactorNettyWebSocketClient();
 
-        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/foo/bar"),
+        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/study/foo/bar"),
             session -> session.send(Flux.just(session.textMessage("bad\r\ntoken")))
                 .then(session.closeStatus()
                     .doOnNext(status -> assertThat(status.getCode()).isEqualTo(1008))
@@ -114,7 +139,7 @@ class WsDataAuthProxyTest {
     void authTimeoutClosesConnection() {
         ReactorNettyWebSocketClient client = new ReactorNettyWebSocketClient();
 
-        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/foo/bar"),
+        client.execute(URI.create("ws://localhost:" + gatewayPort + "/ws-dataauth/study/foo/bar"),
             session -> session.closeStatus()
                 .doOnNext(status -> assertThat(status.getCode()).isEqualTo(1008))
                 .then())


### PR DESCRIPTION
Vibe coded using fable 5.0

<!-- DO NOT FORGET TO UPDATE README.MD OR OTHER DOCUMENTATION IF NEEDED-->

## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

## Add first-frame WebSocket auth proxy endpoint

Works around the browser limitation of not being able to set an `Authorization` header on WebSocket connections.

### Behavior
- New endpoint `/ws-dataauth/**` (handler mapping order `-1`, bypasses gateway routes — documented in Javadoc).
- The **first WebSocket text frame** from the client is consumed (never forwarded) and copied **verbatim** to `Authorization: Bearer <token>` on a new upstream handshake.
- Upstream is always `ws://localhost:<ws-dataauth.upstream-port>`, with the `/ws-dataauth` prefix stripped: `/ws-dataauth/foo/bar?x=y` → `/foo/bar?x=y`.
- No token validation by design — authentication is delegated to the upstream service.
- Auth timeout (default 5 s) and token size limit (default 8 KB); printable-ASCII check prevents header injection.
- Transparent bidirectional relay afterwards; upstream rejection/failure is reported to the client via close code 1008 with detail.
- Frame relay uses `retain()` + `doOnDiscard` to avoid pooled buffer leaks on cancellation races.

### Config
```yaml
ws-dataauth:
  enabled: true
  upstream-port: 80
  auth-timeout: 5s
  max-token-bytes: 8192
```

### Tests
Integration tests with a real Reactor Netty upstream: header propagation, token-not-forwarded, echo relay, query/path mapping, invalid token, auth timeout, upstream failure.

